### PR TITLE
feat(sushi): Adds sushiswap related addresses and entities.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "web3modal": "^1.5.0"
   },
   "devDependencies": {
+    "@sushiswap/sdk": "^3.0.2",
     "@types/jest": "^26.0.7",
     "@types/node": "^14.0.26",
     "@typescript-eslint/eslint-plugin": "^4.4.1",

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -93,6 +93,9 @@ export const getIconForMarket = (key) => {
 
 export const ADDRESS_ZERO = '0x0000000000000000000000000000000000000000'
 export const UNI_ROUTER_ADDRESS = '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D'
+export const SUSHI_ROUTER_ADDRESS = '0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F'
+export const SUSHI_FACTORY_ADDRESS =
+  '0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac'
 
 export const STABLECOINS: { [key: number]: Token } = {
   1: new Token(
@@ -113,6 +116,10 @@ export const STABLECOINS: { [key: number]: Token } = {
 
 export const UNISWAP_CONNECTOR: { [key: number]: string } = {
   1: UniswapConnector.address, // FIX
+  4: UniswapConnectorTestnet.address,
+}
+export const SUSHISWAP_CONNECTOR: { [key: number]: string } = {
+  1: '0xb026991da22f7D8F51550D5f99C39DdBc1c02089', // FIX
   4: UniswapConnectorTestnet.address,
 }
 
@@ -156,4 +163,12 @@ export enum Operation {
   NEW_MARKET,
   NONE,
   APPROVE,
+}
+
+export enum Venue {
+  UNISWAP,
+  SUSHISWAP,
+  BALANCER,
+  SHELL,
+  CURVE,
 }

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -1,3 +1,5 @@
 export * from './option'
 export * from './trade'
-export * from './market'
+export * from './uniMarket'
+export * from './sushiMarket'
+export * from './registry'

--- a/src/entities/option.ts
+++ b/src/entities/option.ts
@@ -1,18 +1,22 @@
 import ethers, { BigNumberish, BigNumber } from 'ethers'
 import OptionArtifact from '@primitivefi/contracts/artifacts/Option.json'
 import { formatEther, parseEther } from 'ethers/lib/utils'
-import { ChainId, Pair, Token, TokenAmount } from '@uniswap/sdk'
+import { ChainId, Token, TokenAmount } from '@uniswap/sdk'
+import * as UniswapSDK from '@uniswap/sdk'
+import * as SushiSwapSDK from '@sushiswap/sdk'
 import { STABLECOINS, ADDRESS_ZERO } from '../constants'
 import isZero from '@/utils/isZero'
 
 export interface OptionParameters {
-  base: TokenAmount
-  quote: TokenAmount
+  base: UniswapSDK.TokenAmount | SushiSwapSDK.TokenAmount
+  quote: UniswapSDK.TokenAmount | SushiSwapSDK.TokenAmount
   expiry: number
 }
 
 export const EMPTY_ASSET: Token = new Token(1, ADDRESS_ZERO, 18)
-export const EMPTY_TOKEN_AMOUNT: TokenAmount = new TokenAmount(EMPTY_ASSET, '')
+export const EMPTY_TOKEN_AMOUNT:
+  | UniswapSDK.TokenAmount
+  | SushiSwapSDK.TokenAmount = new TokenAmount(EMPTY_ASSET, '')
 export const EMPTY_OPTION_PARAMETERS: OptionParameters = {
   base: EMPTY_TOKEN_AMOUNT,
   quote: EMPTY_TOKEN_AMOUNT,
@@ -39,7 +43,7 @@ export const createOptionEntityWithAddress = (
 export class Option extends Token {
   public readonly optionParameters: OptionParameters
   public tokenAddresses: string[]
-  public pair: Pair
+  public pair: UniswapSDK.Pair | SushiSwapSDK.Pair
   public constructor(
     optionParameters: OptionParameters,
     chainId: number,
@@ -60,28 +64,39 @@ export class Option extends Token {
     return new ethers.Contract(this.address, OptionArtifact.abi, signer)
   }
 
-  public get pairAddress(): string {
-    const address: string = Pair.getAddress(this.underlying, this.redeem)
+  public get uniswapPairAddress(): string {
+    const address: string = UniswapSDK.Pair.getAddress(
+      this.underlying,
+      this.redeem
+    )
     return address
   }
 
-  public setPair(pair: Pair) {
+  public get sushiswapPairAddress(): string {
+    const address: string = SushiSwapSDK.Pair.getAddress(
+      this.underlying,
+      this.redeem
+    )
+    return address
+  }
+
+  public setPair(pair: UniswapSDK.Pair | SushiSwapSDK.Pair) {
     this.pair = pair
   }
 
-  public get underlying(): Token {
+  public get underlying(): UniswapSDK.Token | SushiSwapSDK.Token {
     return this.optionParameters.base.token
   }
 
-  public get strike(): Token {
+  public get strike(): UniswapSDK.Token | SushiSwapSDK.Token {
     return this.optionParameters.quote.token
   }
 
-  public get baseValue(): TokenAmount {
+  public get baseValue(): UniswapSDK.TokenAmount | SushiSwapSDK.TokenAmount {
     return this.optionParameters.base
   }
 
-  public get quoteValue(): TokenAmount {
+  public get quoteValue(): UniswapSDK.TokenAmount | SushiSwapSDK.TokenAmount {
     return this.optionParameters.quote
   }
 
@@ -89,7 +104,7 @@ export class Option extends Token {
     return this.optionParameters.expiry
   }
 
-  public get redeem(): Token {
+  public get redeem(): UniswapSDK.Token | SushiSwapSDK.Token {
     return new Token(
       this.chainId,
       this.tokenAddresses[2],

--- a/src/entities/registry.ts
+++ b/src/entities/registry.ts
@@ -4,14 +4,15 @@ import RegistryTestnet from '@primitivefi/contracts/deployments/rinkeby/Registry
 import ethers, { BigNumberish, BigNumber } from 'ethers'
 import { parseEther } from 'ethers/lib/utils'
 import { STABLECOINS } from '../constants'
-import { Token } from '@uniswap/sdk'
+import * as UniswapSDK from '@uniswap/sdk'
+import * as SushiSwapSDK from '@sushiswap/sdk'
 
 export const REGISTRY_ADDRESS: { [key: number]: string } = {
   1: RegistryMainnet.address,
   4: RegistryTestnet.address,
 }
 
-export interface OptionParameters {
+interface OptionParameters {
   base: string
   quote: string
   baseValue: BigNumber
@@ -46,7 +47,7 @@ export class Registry {
     return parseEther('1')
   }
 
-  get stablecoin(): Token {
+  get stablecoin(): UniswapSDK.Token | SushiSwapSDK.Token {
     return this.dai
   }
 

--- a/src/entities/sushiMarket.ts
+++ b/src/entities/sushiMarket.ts
@@ -1,0 +1,308 @@
+import { Token, TokenAmount, Pair, Fraction } from '@sushiswap/sdk'
+import ethers, { BigNumber, BigNumberish } from 'ethers'
+import { parseEther } from 'ethers/lib/utils'
+import { Option } from './option'
+import isZero from '@/utils/isZero'
+import { Operation } from '../constants'
+
+export class SushiSwapMarket extends Pair {
+  public readonly option: Option
+  public constructor(
+    option: Option,
+    tokenAmountA: TokenAmount,
+    tokenAmountB: TokenAmount
+  ) {
+    super(tokenAmountA, tokenAmountB)
+    this.option = option
+  }
+
+  public get FEE(): BigNumberish {
+    return 301
+  }
+
+  public get FEE_UNITS(): BigNumberish {
+    return 100000
+  }
+
+  /**
+   * @dev Gets the quantity of longOptionTokens which can be purchased with less than 2% slippage.
+   */
+  public get depth(): TokenAmount {
+    const underlyingReserve: TokenAmount = this.reserveOf(
+      this.option.underlying
+    )
+    const twoPercentOfReserve: BigNumber = BigNumber.from(
+      underlyingReserve.raw.toString()
+    )
+      .mul(2)
+      .div(100)
+
+    let redeemCost: TokenAmount
+    let newPair: Pair
+    if (!twoPercentOfReserve.eq('0') && underlyingReserve.numerator[2]) {
+      ;[redeemCost, newPair] = this.getInputAmount(
+        new TokenAmount(this.option.underlying, twoPercentOfReserve.toString())
+      )
+    } else {
+      redeemCost = new TokenAmount(this.option.redeem, '0')
+    }
+
+    const redeemCostDivMinted = BigNumber.from(redeemCost.raw.toString()).div(
+      this.option.quoteValue.raw.toString()
+    )
+
+    return new TokenAmount(this.option, redeemCostDivMinted.toString())
+  }
+
+  /**
+   * @dev Gets the cost to purchase `outputAmount` of longOptionTokens, denominated in underlyingTokens.
+   * @param outputAmount The quantity of longOptionTokens to purchase (also the quantity of underlyingTokens borrowed).
+   */
+  public getOpenPremium = (outputAmount: TokenAmount): TokenAmount => {
+    if (
+      !this.hasLiquidity ||
+      this.reserveOf(outputAmount.token).greaterThan(outputAmount.raw)
+    ) {
+      return new TokenAmount(this.option.underlying, '0')
+    }
+
+    const redeemPayment = this.option.proportionalShort(
+      outputAmount.raw.toString()
+    )
+    const [amountIn, newPair] = this.getInputAmount(outputAmount)
+    const costRedeem = BigNumber.from(amountIn.raw.toString()).gt(redeemPayment)
+      ? BigNumber.from(amountIn.raw.toString()).sub(redeemPayment)
+      : parseEther('0')
+    const costUnderlying = costRedeem.gt(0)
+      ? this.getOutputAmount(
+          new TokenAmount(this.option.redeem, costRedeem.toString())
+        )[0]
+      : new TokenAmount(this.option.redeem, '0')
+    const premium = BigNumber.from(costUnderlying.raw.toString())
+      .mul(this.FEE_UNITS)
+      .add(BigNumber.from(costUnderlying.raw.toString()).mul(this.FEE))
+      .div(this.FEE_UNITS)
+    return new TokenAmount(this.option.underlying, premium.toString())
+  }
+
+  /**
+   * @dev Spot open premium for calls is: (1 - ( Strike Price * Underlying Reserve / Short Reserve ))
+   *      Spot premium for puts is: (1 - ( Underlying Reserve / ( Short Reserve * Strike Price ))
+   */
+  public get spotOpenPremium(): TokenAmount {
+    if (!this.hasLiquidity) {
+      return new TokenAmount(this.option.underlying, '0')
+    }
+    const one = parseEther('1')
+    let spot
+    if (this.option.isCall) {
+      spot = parseEther(this.option.strikePrice)
+        .mul(this.reserveOf(this.option.underlying).raw.toString())
+        .div(this.reserveOf(this.option.redeem).raw.toString())
+    } else {
+      spot = parseEther('1')
+        .mul(this.reserveOf(this.option.underlying).raw.toString())
+        .div(this.reserveOf(this.option.redeem).raw.toString())
+        .mul(parseEther('1'))
+        .div(parseEther(this.option.strikePrice))
+    }
+    const spotOpenPremium = one.sub(spot).gt(0) ? one.sub(spot) : '0'
+    return new TokenAmount(this.option.underlying, spotOpenPremium.toString())
+  }
+
+  /**
+   * @dev Gets the payout for selling the proprotional longOptionToken amount of `outputAmount`.
+   * @param outputAmount The quantity of shortOptionTokens per optionToken that needs to be closed.
+   */
+  public getClosePremium = (outputAmount: TokenAmount): TokenAmount => {
+    if (
+      !this.hasLiquidity ||
+      this.reserveOf(outputAmount.token).greaterThan(outputAmount.raw)
+    ) {
+      return new TokenAmount(this.option.underlying, '0')
+    }
+    const underlyingsMinted = this.option.proportionalLong(
+      outputAmount.raw.toString()
+    )
+    const [amountIn, newPair] = this.getInputAmount(outputAmount)
+    const payout = underlyingsMinted.gt(amountIn.raw.toString())
+      ? underlyingsMinted.sub(amountIn.raw.toString())
+      : parseEther('0')
+    return new TokenAmount(this.option.underlying, payout.toString())
+  }
+
+  public get spotClosePremium(): TokenAmount {
+    if (!this.hasLiquidity) {
+      return new TokenAmount(this.option.underlying, '0')
+    }
+    const one = parseEther('1')
+    const spot = parseEther('1')
+      .mul(this.reserveOf(this.option.underlying).raw.toString())
+      .div(
+        this.option.proportionalLong(
+          this.reserveOf(this.option.redeem).raw.toString()
+        )
+      )
+    const spotClosePremium = one.sub(spot).gt(0) ? one.sub(spot) : '0'
+    return new TokenAmount(this.option.underlying, spotClosePremium.toString())
+  }
+
+  /**
+   * @dev Gets the cost to purchase `inputAmount` of shortOptionTokens, denominated in underlyingTokens.
+   * @param inputAmount Quantity of shortOptionTokens to purchase.
+   */
+  public getShortPremium = (inputAmount: TokenAmount): TokenAmount => {
+    if (!this.hasLiquidity) {
+      return new TokenAmount(this.option.underlying, '0')
+    }
+
+    const [amountOut, newPair] = this.getOutputAmount(inputAmount)
+    return amountOut
+  }
+
+  public get spotShortToUnderlying(): TokenAmount {
+    return new TokenAmount(
+      this.option.redeem,
+      parseEther(
+        this.priceOf(this.option.underlying).raw.toSignificant(6)
+      ).toString()
+    )
+  }
+
+  public get spotUnderlyingToShort(): TokenAmount {
+    return new TokenAmount(
+      this.option.underlying,
+      parseEther(
+        this.priceOf(this.option.redeem).raw.toSignificant(6)
+      ).toString()
+    )
+  }
+
+  /**
+   * @dev Gets the spot price, actual execution price, and slippage based on the spot * size product.
+   * @param orderType The order type which will be executed.
+   * @param inputAmount The size of the order.
+   * @returns Spot, Actual, Slippage
+   */
+  public getExecutionPrice = (
+    orderType: Operation,
+    inputAmount: BigNumberish
+  ): [TokenAmount, TokenAmount, number] => {
+    let parsedAmount: TokenAmount
+    let spot: TokenAmount
+    let actualPremium: TokenAmount
+    let slippage: number
+    if (orderType === Operation.LONG) {
+      parsedAmount = new TokenAmount(
+        this.option.underlying,
+        inputAmount.toString()
+      )
+      spot = this.spotOpenPremium
+      actualPremium = this.getOpenPremium(parsedAmount)
+      const spotSize = BigNumber.from(inputAmount)
+        .mul(spot.raw.toString())
+        .div(parseEther('1'))
+      slippage =
+        (parseInt(actualPremium.raw.toString()) /
+          parseInt(spotSize.toString()) -
+          1) *
+        100
+      // sell long, Trade.getClosePremium
+    } else if (
+      orderType === Operation.CLOSE_LONG ||
+      orderType === Operation.WRITE
+    ) {
+      spot = this.spotClosePremium
+      const shortSize = this.option.proportionalShort(inputAmount)
+      parsedAmount = new TokenAmount(this.option.redeem, shortSize.toString())
+      actualPremium = this.getClosePremium(parsedAmount)
+      const spotSize = BigNumber.from(inputAmount)
+        .mul(spot.raw.toString())
+        .div(parseEther('1'))
+      slippage =
+        (parseInt(actualPremium.raw.toString()) /
+          parseInt(spotSize.toString()) -
+          1) *
+        100
+      // buy short swap from UNDER -> RDM
+    } else if (orderType === Operation.SHORT) {
+      parsedAmount = new TokenAmount(this.option.redeem, inputAmount.toString())
+      spot = this.spotUnderlyingToShort
+      const spotSize = BigNumber.from(inputAmount)
+        .mul(spot.raw.toString())
+        .div(parseEther('1'))
+      actualPremium = this.getInputAmount(parsedAmount)[0]
+      slippage =
+        (parseInt(actualPremium.raw.toString()) /
+          parseInt(spotSize.toString()) -
+          1) *
+        100
+      // sell short, RDM -> UNDER
+    } else if (orderType === Operation.CLOSE_SHORT) {
+      parsedAmount = new TokenAmount(this.option.redeem, inputAmount.toString())
+      spot = this.spotUnderlyingToShort
+      const spotSize = BigNumber.from(inputAmount)
+        .mul(spot.raw.toString())
+        .div(parseEther('1'))
+      actualPremium = this.getShortPremium(parsedAmount)
+      slippage =
+        (parseInt(actualPremium.raw.toString()) /
+          parseInt(spotSize.toString()) -
+          1) *
+        100
+    }
+    return [spot, actualPremium, slippage]
+  }
+
+  public getOptionsAddedAsLiquidity = (
+    inputAmount: TokenAmount
+  ): TokenAmount => {
+    const ratio = this.option.proportionalShort(
+      this.option.baseValue.raw.toString()
+    )
+    const denominator = ratio
+      .mul(this.reserveOf(this.option.underlying).raw.toString())
+      .div(this.reserveOf(this.option.redeem).raw.toString())
+      .add(parseEther('1'))
+
+    const optionsInput = BigNumber.from(inputAmount.raw.toString())
+      .mul(parseEther('1'))
+      .div(denominator)
+
+    return new TokenAmount(this.option.underlying, optionsInput.toString())
+  }
+
+  public getLiquidityValuePerShare = (
+    totalSupply: TokenAmount,
+    feeOn = false,
+    kLast?: BigNumberish
+  ): [TokenAmount, TokenAmount, TokenAmount] => {
+    const shortValue = this.getLiquidityValue(
+      this.option.redeem,
+      new TokenAmount(this.liquidityToken, totalSupply.raw.toString()),
+      new TokenAmount(this.liquidityToken, parseEther('1').toString())
+    )
+
+    const underlyingValue = this.getLiquidityValue(
+      this.option.underlying,
+      new TokenAmount(this.liquidityToken, totalSupply.raw.toString()),
+      new TokenAmount(this.liquidityToken, parseEther('1').toString())
+    )
+
+    const totalUnderlyingValue = new TokenAmount(
+      this.option.underlying,
+      BigNumber.from(shortValue.raw.toString())
+        .mul(this.option.baseValue.raw.toString())
+        .div(this.option.quoteValue.raw.toString())
+        .add(underlyingValue.raw.toString())
+        .toString()
+    )
+
+    return [shortValue, underlyingValue, totalUnderlyingValue]
+  }
+  public get hasLiquidity(): boolean {
+    const reserve0Liquidity: boolean = this.reserve0.greaterThan('0')
+    const reserve1Liquidity: boolean = this.reserve1.greaterThan('0')
+    return reserve0Liquidity && reserve1Liquidity
+  }
+}

--- a/src/entities/uniMarket.ts
+++ b/src/entities/uniMarket.ts
@@ -5,7 +5,7 @@ import { Option } from './option'
 import isZero from '@/utils/isZero'
 import { Operation } from '../constants'
 
-export class Market extends Pair {
+export class UniswapMarket extends Pair {
   public readonly option: Option
   public constructor(
     option: Option,

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -12,6 +12,7 @@ import UniswapV2Factory from '@uniswap/v2-core/build/UniswapV2Factory.json'
 import { Token, TokenAmount } from '@uniswap/sdk'
 import MultiCall from './multicall'
 import { FACTORY_ADDRESS } from '@uniswap/sdk'
+import { Venue, SUSHI_FACTORY_ADDRESS } from './constants'
 
 /**
  * Methods for asyncronously getting on-chain data and returning SDK classes using the data.
@@ -120,9 +121,15 @@ export class Protocol {
 
   public static async getPairsFromMultiCall(
     provider,
-    tokensArray
+    tokensArray,
+    venue?: Venue
   ): Promise<any> {
     const multi = new MultiCall(provider)
+    const factoryAddress = venue
+      ? venue === Venue.SUSHISWAP
+        ? SUSHI_FACTORY_ADDRESS
+        : FACTORY_ADDRESS
+      : FACTORY_ADDRESS
 
     const chunks = Protocol.chunkArray(tokensArray, 10)
     const datas = []
@@ -131,7 +138,7 @@ export class Protocol {
       const inputs = []
       for (const tokenArray of chunk) {
         inputs.push({
-          target: FACTORY_ADDRESS,
+          target: factoryAddress,
           function: 'getPair',
           args: [tokenArray[0], tokenArray[1]],
         })

--- a/src/trader.ts
+++ b/src/trader.ts
@@ -115,7 +115,6 @@ export class Trader {
           )
           methodName = 'safeCloseForETH'
         } else {
-          console.log(trade.option.getTimeToExpiry())
           if (trade.option.getTimeToExpiry() <= 0) {
             methodName = 'safeUnwind'
           } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1557,6 +1557,19 @@
   dependencies:
     type-detect "4.0.8"
 
+"@sushiswap/sdk@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@sushiswap/sdk/-/sdk-3.0.2.tgz#2d8db96168bf4b224edfc33b1404742431aa3726"
+  integrity sha512-cuI2NGd6V6R00nj70MmJZi9/LoRD0Wjz0ytDRajWrRq8ohO5/CNsQRuQyezCqgJkPklENT6UzJ05rX+eVMuKcA==
+  dependencies:
+    "@uniswap/v2-core" "^1.0.0"
+    big.js "^5.2.2"
+    decimal.js-light "^2.5.0"
+    jsbi "^3.1.1"
+    tiny-invariant "^1.1.0"
+    tiny-warning "^1.0.3"
+    toformat "^2.0.0"
+
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"


### PR DESCRIPTION
- Adds Sushiswap router + factory address to /constants
- Adds SushiSwapConnector address to SUSHISWAP_CONNECTORS in /constants
- Adds Venue enum in /constants
- Updates `trade.ts` constructor with a `venue` parameter that will specify the venue enum.
- Updates `uniswap.ts` class with a conditional based on `trade.venue` to get the appropriate addresses required. Checks the v enue and will get a uniswap/sushiswap connector/router address based on it.
- Updates `Protocol.getPairsFromMultiCall` with an optional `venue` parameter. If the `venue` parameter is passed to this function, it will check if the venue is Venue.SUSHISWAP. If true, it will use the sushiswap factory address. If not, or if there is no venue parameter, it will default to the uniswap factory address for the `getPairs` multicall.
- Changes `market.ts` to `uniMarket.ts` and `sushiMarket.ts`. This is because they import their respective SDKs. This is needed because they both extend the `Pair` entity from the sdk. The `Pair` entity uses a static function `Pair.getAddress` when a new `Pair` entity is constructed. This static function uses the constant `INIT_HASH` and `FACTORY_ADDRESS`, which are different for the uniswap/sushiswap sdks.
- Updates `option.ts` with the new `Pair` entity types, either from the UniswapSDK or SushiSwapSDK.
- Updates `option.pairAddress` getter. Removes `pairAddress` and adds `uniswapPairAddress` and `sushiswapPairAddress`. These functions call their respective SDK `Pair` entities.


To fix on the interface side:
- Add conditional when instantiating `Market` entities to check the venue, and use the respective `UniswapMarket` or `SushiSwapMarket` entities.
- Add the conditional `venue` parameter when fetching pairs with multicall using `Protocol.getPairsFromMulticall`.
- Add the `venue` parameter to all `Trade` entities.
- Update approvals with a `venue` parameter and to approve the respective addresses based on venue.